### PR TITLE
consistent usage of 'function'

### DIFF
--- a/firmware/examples/clickButtonDemo.cpp
+++ b/firmware/examples/clickButtonDemo.cpp
@@ -49,9 +49,9 @@ void loop()
   button1.Update();
 
   // Save click codes in LEDfunction, as click codes are reset at next Update()
-  if (button1.clicks != 0) function = button1.clicks;
+  if(button1.clicks != 0) function = button1.clicks;
   
-  if(button1.clicks == 1) Serial.println("SINGLE click");
+  if(function == 1) Serial.println("SINGLE click");
 
   if(function == 2) Serial.println("DOUBLE click");
 


### PR DESCRIPTION
Making the "single click" also use the function var for consistency. Also removed a whitespace so the conditional statements match.