### PR TITLE
small changes to compile on raspberry pi

### DIFF
--- a/src/clickButton.cpp
+++ b/src/clickButton.cpp
@@ -98,11 +98,22 @@ ClickButton::ClickButton(uint8_t buttonPin, boolean activeType, boolean internal
   multiclickTime = 250;           // Time limit for multi clicks
   longClickTime  = 1000;          // time until "long" click register
 
+// Particle devices
+#if defined PLATFORM_ID
   // Turn on internal pullup resistor if applicable
   if (_activeHigh == LOW && internalPullup == CLICKBTN_PULLUP)
     pinMode(_pin, INPUT_PULLUP);
   else
     pinMode(_pin, INPUT_PULLDOWN);
+// Raspberry Pi
+#else
+  pinMode(_pin, INPUT);
+  // Turn on internal pullup resistor if applicable
+  if (_activeHigh == LOW && internalPullup == CLICKBTN_PULLUP)
+    pullUpDnControl(_pin, PUD_UP);
+  else
+    pullUpDnControl(_pin, PUD_DOWN);
+#endif
 }
 
 
@@ -144,4 +155,3 @@ void ClickButton::Update()
 
   _lastState = _btnState;
 }
-

--- a/src/clickButton.h
+++ b/src/clickButton.h
@@ -50,7 +50,19 @@ NOTE!
 */
 
 // -------- clickButton.h --------
-#include "Particle.h"
+
+// Particle devices
+#if defined PLATFORM_ID
+  #include "Particle.h"
+// Raspberry Pi
+#else
+  // for uint8_t
+  #include "stdint.h"
+  // for GPIO functionality
+  #include <wiringPi.h>
+
+  typedef uint8_t boolean;
+#endif
 
 #define CLICKBTN_PULLUP HIGH
 


### PR DESCRIPTION
See #15 
This pull request adds the minimum code to allow the Raspberry Pi to compile the library. I've also tested the new code on the Particle cloud and it compiles there too.

The source changes because wiringPi sets up pull-ups/downs a little differently.
The header changes to bring in some extra libraries and types to make it compatible.