### PR TITLE
Missing arch entry

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,3 +5,4 @@ author=Paul Kourany/raron, raronzen@gmail.com
 sentence=clickButton Library
 url=https://github.com/pkourany/clickButton
 repository=https://github.com/pkourany/clickButton.git
+architectures=*


### PR DESCRIPTION
Atmel studio wouldn't import or list libraries without.